### PR TITLE
fix sl_mat_set_to_uchar2 and typos

### DIFF
--- a/include/sl/c_api/zed_interface.h
+++ b/include/sl/c_api/zed_interface.h
@@ -67,8 +67,8 @@ extern "C" {
     \param ip : ip of the camera to open (for Stream input).
     \param stream_port : port of the camera to open (for Stream input).
     \param output_file : sdk verbose log file. Redirect the SDK verbose message to file.
-    \param opt_settings_path : optionnal settings path. Equivalent to  \ref InitParameters::optional_settings_path.
-    \param opencv_calib_path : optionnal openCV calibration file. Equivalent to  \ref InitParameters::optional_opencv_calibration_file.
+    \param opt_settings_path : optional settings path. Equivalent to  \ref InitParameters::optional_settings_path.
+    \param opencv_calib_path : optional openCV calibration file. Equivalent to  \ref InitParameters::optional_opencv_calibration_file.
     \return An error code giving information about the internal process. If SUCCESS (0) is returned, the camera is ready to use. Every other code indicates an error and the program should be stopped.
     */
     INTERFACE_API int sl_open_camera(int camera_id, struct SL_InitParameters *init_parameters, const char* path_svo, const char* ip, int stream_port, const char* output_file, const char* opt_settings_path, const char* opencv_calib_path);
@@ -95,7 +95,7 @@ extern "C" {
 
     /**
     \brief Destroys the camera and disable the textures.
-    \param camera_idid of the camera instance.
+    \param camera_id : id of the camera instance.
      */
     INTERFACE_API void sl_close_camera(int camera_id);
     /**

--- a/src/zed_interface.cpp
+++ b/src/zed_interface.cpp
@@ -1177,7 +1177,7 @@ extern "C" {
 
     INTERFACE_API int sl_mat_set_to_uchar2(int* ptr, SL_Uchar2 value, enum SL_MEM mem) {
         sl::uchar2 f = sl::uchar2(value.x, value.y);
-        return (int) (MAT->setTo<sl::uchar2>(f, (sl::MEM)mem));
+        return (int) (MAT->setTo<sl::uchar2>(f, (sl::MEM)(mem + 1)));
 
     }
 


### PR DESCRIPTION
The current `sl_mat_set_to_uchar2` returns `SL_ERROR_CODE_FAILURE` in the following minimal working example. 
```
#include <sl/c_api/zed_interface.h>
#include <stdbool.h>
#include <stdio.h>

int main(int argc, char **argv) {
    //Create image ptr.
    int* image_ptr;
    // Init pointer.
    int width = 100;
    int height = 200;
    image_ptr = sl_mat_create_new(width, height, SL_MAT_TYPE_U8_C2, SL_MEM_CPU);

    unsigned char x = 10;
    unsigned char y = 20;
    struct SL_Uchar2 value;
    value.x = x;
    value.y = y;
    int set_err;
    set_err = sl_mat_set_to_uchar2(image_ptr, value, SL_MEM_CPU);
    printf("%d\n", set_err);

    return 0;
}
```
After the change (SL_MEM indexing starts from 1), `sl_mat_set_to_uchar2` returns `SL_ERROR_CODE_SUCCESS`.