### PR TITLE
fix 'error: ‘shared_ptr’ in namespace ‘std’ does not name a template …

### DIFF
--- a/src/ZEDController.hpp
+++ b/src/ZEDController.hpp
@@ -1,7 +1,7 @@
 #ifndef __ZED_CONTROLLER_H__
 #define __ZED_CONTROLLER_H__
 
-
+#include <memory>
 #include <sl/Camera.hpp>
 #ifdef _WIN32
 #include <Windows.h>

--- a/src/zed_interface.cpp
+++ b/src/zed_interface.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <thread>
 #include <mutex>
 #include <chrono>


### PR DESCRIPTION
…type'