### PR TITLE
Fix ZEDController::destroyInstance

### DIFF
--- a/src/ZEDController.hpp
+++ b/src/ZEDController.hpp
@@ -30,7 +30,7 @@ public:
     }
 
     static void destroyInstance(int i) {
-        if (!instance[i]) // Only allow one instance of class to be generated.
+        if (instance[i])
             delete instance[i];
         instance[i] = nullptr;
 


### PR DESCRIPTION
Seems that `ZEDController::destroyInstance` is calling `delete` on null pointers. 