### PR TITLE
Fix sensor batch output allocation

### DIFF
--- a/include/sl/c_api/ZEDController.hpp
+++ b/include/sl/c_api/ZEDController.hpp
@@ -291,6 +291,7 @@ private:
 
     bool isSensorsBatchReady = false;
     std::vector<sl::SensorsData> sensorsDataBatch;
+    std::vector<SL_SensorsData> sensorsDataBatchC;
 
     bool saveTexture;
     sl::Mesh mesh;

--- a/include/sl/c_api/zed_interface.h
+++ b/include/sl/c_api/zed_interface.h
@@ -936,7 +936,8 @@ extern "C" {
     INTERFACE_API int sl_get_sensors_data_batch_count(int camera_id, int* count);
     /**
     \brief Retrieves all SL_SensorsData associated to most recent grabbed frame in the specified \ref COORDINATE_SYSTEM of InitParameters.
-	\note sl_get_sensors_data_batch needs to be called before this function to retrieve the size of the imu batch array.
+	\note sl_get_sensors_data_batch_count needs to be called before this function to retrieve the size of the imu batch array.
+    \note The returned array is owned by the API and remains valid until the next call to this function for the same camera.
     \param [out] data : The SensorsData array to store the data.
     \param camera_id : Id of the camera instance.
     \return \ref SL_ERROR_CODE "SL_ERROR_CODE_SUCCESS" if sensors data have been extracted.

--- a/src/ZEDController.cpp
+++ b/src/ZEDController.cpp
@@ -634,16 +634,18 @@ sl::ERROR_CODE ZEDController::getSensorsDataBatch(SL_SensorsData** data)
 {
     if (!isNull())
     {
+        if (data == nullptr)
+            return sl::ERROR_CODE::INVALID_FUNCTION_PARAMETERS;
+
         if (isSensorsBatchReady)
         {
             int size = sensorsDataBatch.size();
-
-            memset(*data, 0, sizeof(SL_SensorsData) * size);
+            sensorsDataBatchC.assign(size, {});
+            *data = sensorsDataBatchC.data();
 
             for (int i = 0; i < size; i++)
             {
-
-                SL_SensorsData* sensorData = data[i];
+                SL_SensorsData* sensorData = &sensorsDataBatchC[i];
                 sl::SensorsData tmp_sensor_data = sensorsDataBatch[i];
 
                 sensorData->camera_moving_state = (int)tmp_sensor_data.camera_moving_state;
@@ -672,10 +674,10 @@ sl::ERROR_CODE ZEDController::getSensorsDataBatch(SL_SensorsData** data)
                 sensorData->imu.orientation.z = tmp_sensor_data.imu.pose.getOrientation().z;
                 sensorData->imu.orientation.w = tmp_sensor_data.imu.pose.getOrientation().w;
 
-                for (int i = 0; i < 9; i++) {
-                    sensorData->imu.angular_velocity_convariance.p[i] = tmp_sensor_data.imu.angular_velocity_covariance.r[i];
-                    sensorData->imu.linear_acceleration_convariance.p[i] = tmp_sensor_data.imu.linear_acceleration_covariance.r[i];
-                    sensorData->imu.orientation_covariance.p[i] = tmp_sensor_data.imu.pose_covariance.r[i];
+                for (int covariance_index = 0; covariance_index < 9; covariance_index++) {
+                    sensorData->imu.angular_velocity_convariance.p[covariance_index] = tmp_sensor_data.imu.angular_velocity_covariance.r[covariance_index];
+                    sensorData->imu.linear_acceleration_convariance.p[covariance_index] = tmp_sensor_data.imu.linear_acceleration_covariance.r[covariance_index];
+                    sensorData->imu.orientation_covariance.p[covariance_index] = tmp_sensor_data.imu.pose_covariance.r[covariance_index];
                 }
 
                 ///Barometer

--- a/src/ZEDController.hpp
+++ b/src/ZEDController.hpp
@@ -290,6 +290,7 @@ private:
 
     bool isSensorsBatchReady = false;
     std::vector<sl::SensorsData> sensorsDataBatch;
+    std::vector<SL_SensorsData> sensorsDataBatchC;
 
     bool saveTexture;
     sl::Mesh mesh;


### PR DESCRIPTION
## Summary

- store converted C sensor samples in a controller-owned contiguous buffer
- return that buffer through the `SL_SensorsData**` output parameter
- remove the invalid dereference of an uninitialized output pointer
- index the contiguous sensor array correctly and remove covariance-loop shadowing
- document the returned pointer lifetime and correct the prerequisite function name

## Root cause

`getSensorsDataBatch()` called `memset(*data, ...)` before assigning `*data`, then treated `data` itself as an array of sample pointers. The public C# wrapper expects one contiguous `SensorsData` array and advances through it by `sizeof(SensorsData)`, so both operations could produce invalid memory access.

The new buffer remains owned by the controller and valid until the next batch retrieval for that camera, matching the existing wrapper contract without transferring allocation ownership across the C ABI.

## Validation

- verified the pointer layout against the public `zed-csharp-api` batch marshalling implementation
- `git diff --check`

A full build requires the proprietary ZED SDK and is left to project CI.

Closes #31
